### PR TITLE
Bugfix/small fixes

### DIFF
--- a/lib/src/browser/mount.dart
+++ b/lib/src/browser/mount.dart
@@ -3,6 +3,7 @@ part of tiles_browser;
 const _REF = "ref";
 const _VALUE = "value";
 const _DEFAULTVALUE = "defaultValue";
+const _DANGEROUSLYSETINNERHTML = "dangerouslySetInnerHTML";
 
 /**
  * Map needed when doing updates on dom.
@@ -96,7 +97,11 @@ _mountNode(Node node, html.HtmlElement mountRoot, {Node nextNode}) {
     _saveRelations(node, componentElement);
 
     _applyAttributes(componentElement, component.props, svg: component.svg, node: node, listeners: node.listeners);
-    node.children.forEach((Node child) => _mountNode(child, componentElement));
+    if(component.props.containsKey(_DANGEROUSLYSETINNERHTML)){
+      _dangerouslySetInnerHTML(component, componentElement);
+    } else {
+      node.children.forEach((Node child) => _mountNode(child, componentElement));
+    }
 
     if (nextNode != null) {
       mountRoot.insertBefore(componentElement, _nodeToElement[nextNode]);
@@ -133,6 +138,13 @@ _mountNode(Node node, html.HtmlElement mountRoot, {Node nextNode}) {
       node.component.props[_REF](node.component);
     }
   } catch (e) {}
+}
+
+void _dangerouslySetInnerHTML(DomComponent component, html.Element element) {
+  if(component.children != null) {
+    throw new Exception("Component with dangerously setted inner html should not have childre");
+  }
+  element.setInnerHtml(component.props[_DANGEROUSLYSETINNERHTML]);
 }
 
 /**

--- a/lib/src/browser/mount.dart
+++ b/lib/src/browser/mount.dart
@@ -142,8 +142,24 @@ _mountNode(Node node, html.HtmlElement mountRoot, {Node nextNode}) {
  */
 _canAddAttribute(bool svg, String key) {
   return (!svg && allowedAttrs.contains(key))
-      || (svg && allowedSvgAttributes.contains(key));
+      || (svg && allowedSvgAttributes.contains(key)) 
+      || _matchAllowedPrefix(key);
 
+}
+
+/**
+ * tells if the key match some of allowed prefixes
+ */
+bool _matchAllowedPrefix(String key) {
+  bool match = false;
+  
+  allowedAttrsPrefixes.forEach((prefix) {
+    if (key.startsWith(prefix)) {
+      match = true;
+    }
+  });
+
+  return match;
 }
 
 /**

--- a/lib/src/browser/mount.dart
+++ b/lib/src/browser/mount.dart
@@ -27,6 +27,10 @@ typedef void _Ref(Component component);
  */
 mountComponent(ComponentDescription description, html.HtmlElement mountRoot) {
   logger.fine("mountComponent called");
+  
+  if(_isMounted(description, mountRoot)) {
+    return _remountDescription(description, mountRoot);
+  }
 
   Node node = new Node.fromDescription(null, description);
 
@@ -42,6 +46,16 @@ mountComponent(ComponentDescription description, html.HtmlElement mountRoot) {
    * mount root node to mount root to be able easy unmount node.
    */
   _elementToNode[mountRoot] = node;
+}
+
+void _remountDescription(ComponentDescription description, html.HtmlElement mountRoot) {
+  Node node = _elementToNode[mountRoot];
+  node.apply(props: description.props, children: description.children, listeners: description.listeners);
+  node.isDirty = true;
+}
+
+bool _isMounted(ComponentDescription description, html.HtmlElement mountRoot) {
+  return _elementToNode[mountRoot] != null && _elementToNode[mountRoot].factory == description.factory;
 }
 
 /**

--- a/lib/src/browser/updates.dart
+++ b/lib/src/browser/updates.dart
@@ -161,6 +161,11 @@ _applyUpdatedChange(NodeChange change) {
      * change or remove old attributes
      */
     _applyAttributes(element, newProps, svg: component.svg, node: change.node, oldProps: oldProps, listeners: change.node.listeners);
+    if(component.props.containsKey(_DANGEROUSLYSETINNERHTML)){
+      _dangerouslySetInnerHTML(component, element);
+    }
+
+
   } else if (change.node.component is DomTextComponent) {
     /**
      * if component is dom text componetn, update text of the element

--- a/lib/src/browser/updates.dart
+++ b/lib/src/browser/updates.dart
@@ -36,8 +36,11 @@ initTilesBrowserConfiguration() {
  */
 _update(num data) {
   logger.finer("_update called");
-  _updateTrees();
-  html.window.animationFrame.then(_update);
+  try {
+    _updateTrees();
+  } finally {
+    html.window.animationFrame.then(_update);
+  }
 }
 
 /**
@@ -243,4 +246,3 @@ _removeNodeFromDom(Node node) {
     }
   }
 }
-

--- a/lib/src/core/node_update_children.dart
+++ b/lib/src/core/node_update_children.dart
@@ -15,17 +15,17 @@ _updateChildren (Node node, {List<NodeChange> changes}) {
   Map<dynamic, Node> oldChildren = _createChildrenMap(node.children);
   Map<dynamic, num> oldChildrenPositions = _createPositionMap(oldChildren.keys);
   List<Node> nextChildren = [];
-  List<ComponentDescription> descriptions = _getChildrenFromComponent(node.component);
+  Iterable<ComponentDescription> descriptions = _getChildrenFromComponent(node.component);
 
   logger.finer('component: ${node.component.props}');
 
-  for (num i = 0; i < descriptions.length; ++i) {
-    dynamic key = descriptions[i].key;
+  var index = 0;
+  descriptions.forEach((ComponentDescription description) {
+    dynamic key = description.key;
     if (key == null) {
-      key = i;
+      key = index;
     }
 
-    ComponentDescription description = descriptions[i];
     Node oldChild = oldChildren[key];
     Node nextChild;
 
@@ -37,7 +37,7 @@ _updateChildren (Node node, {List<NodeChange> changes}) {
       nextChild = oldChild;
       Map oldListeners = nextChild.listeners;
       nextChild.apply(props: description.props, children: description.children, listeners: description.listeners);
-      if (i != oldChildrenPositions[key]) {
+      if (index != oldChildrenPositions[key]) {
         _addChanges(new NodeChange(NodeChangeType.MOVED, nextChild), changes);
       }
 
@@ -58,7 +58,8 @@ _updateChildren (Node node, {List<NodeChange> changes}) {
       }
     }
     nextChildren.add(nextChild);
-  }
+    ++index;
+  });
   for (Node child in oldChildren.values) {
     logger.finer("removin old child");
     _addChanges(new NodeChange(NodeChangeType.DELETED, child), changes);
@@ -84,7 +85,7 @@ Map<dynamic, Node> _createChildrenMap (List<Node> nodes) {
 }
 
 
-List<ComponentDescription> _getChildrenFromComponent(Component component) {
+Iterable<ComponentDescription> _getChildrenFromComponent(Component component) {
   logger.finer("_getChildrenFromComponent");
   var rawChildren = component.render();
   if (rawChildren is ComponentDescription) {
@@ -92,9 +93,9 @@ List<ComponentDescription> _getChildrenFromComponent(Component component) {
      * if render returns componentDescription, construct newChildren list
      */
     return [rawChildren];
-  } else if (rawChildren is List<ComponentDescription>) {
+  } else if (rawChildren is Iterable<ComponentDescription>) {
     /**
-     * if render returns List<componentDescription> set newChildren to it
+     * if render returns Iterable<componentDescription> set newChildren to it
      */
     return rawChildren;
   } else if (rawChildren == null) {
@@ -107,7 +108,7 @@ List<ComponentDescription> _getChildrenFromComponent(Component component) {
     /**
      * if it returns something else, throw exception
      */
-    throw "render should return ComponentDescription or List<ComponentDescription>";
+    throw "render should return ComponentDescription or Iterable<ComponentDescription>";
   }
 }
 

--- a/lib/src/dom/dom_component.dart
+++ b/lib/src/dom/dom_component.dart
@@ -6,7 +6,7 @@ class DomComponent extends Component {
 
   Map _props;
 
-  set props (Map data) {
+  set props(Map data) {
     if (data != null) {
       _props = data;
     } else {
@@ -18,11 +18,13 @@ class DomComponent extends Component {
 
   final bool svg;
 
-  DomComponent({Map props, List<ComponentDescription> children, this.tagName, pair, this.svg: false}):
-      this._props = props,
-      this.pair = pair == null || pair,
-      super(null, children) {
-    if (_props != null && !(_props is Map)) throw "Props should be map or string";
+  DomComponent({Map props, List<ComponentDescription> children, this.tagName,
+      pair, this.svg: false})
+      : this._props = props,
+        this.pair = pair == null || pair,
+        super(null, children) {
+    if (_props != null &&
+        !(_props is Map)) throw "Props should be map or string";
     if (_props == null) {
       _props = {};
     }
@@ -31,20 +33,114 @@ class DomComponent extends Component {
   List<ComponentDescription> render() {
     return this.children;
   }
-
 }
 
+final Set<String> allowedAttrs = new Set.from([
+  "accept",
+  "accessKey",
+  "action",
+  "allowFullScreen",
+  "allowTransparency",
+  "alt",
+  "autoCapitalize",
+  "autoComplete",
+  "autoFocus",
+  "autoPlay",
+  "cellPadding",
+  "cellSpacing",
+  "charSet",
+  "checked",
+  "class",
+  "cols",
+  "colSpan",
+  "content",
+  "contentEditable",
+  "contextMenu",
+  "controls",
+  "data",
+  "dateTime",
+  "dir",
+  "disabled",
+  "draggable",
+  "encType",
+  "for",
+  "form",
+  "frameBorder",
+  "height",
+  "hidden",
+  "href",
+  "htmlFor",
+  "httpEquiv",
+  "icon",
+  "id",
+  "label",
+  "lang",
+  "list",
+  "loop",
+  "max",
+  "maxLength",
+  "method",
+  "min",
+  "multiple",
+  "name",
+  "pattern",
+  "placeholder",
+  "poster",
+  "preload",
+  "radioGroup",
+  "readOnly",
+  "rel",
+  "required",
+  "role",
+  "rows",
+  "rowSpan",
+  "scrollLeft",
+  "scrollTop",
+  "selected",
+  "size",
+  "spellCheck",
+  "src",
+  "step",
+  "style",
+  "tabIndex",
+  "target",
+  "title",
+  "type",
+  "value",
+  "defaultValue",
+  "width",
+  "wmode"
+]);
 
-final Set<String> allowedAttrs = new Set.from(["accept", "accessKey", "action", "allowFullScreen", "allowTransparency", "alt", "autoCapitalize",
-  "autoComplete", "autoFocus", "autoPlay", "cellPadding", "cellSpacing", "charSet", "checked",
-  "class", "cols", "colSpan", "content", "contentEditable", "contextMenu", "controls", "data", "dateTime",
-  "dir", "disabled", "draggable", "encType", "for", "form", "frameBorder", "height", "hidden", "href", "htmlFor",
-  "httpEquiv", "icon", "id", "label", "lang", "list", "loop", "max", "maxLength", "method", "min", "multiple", "name",
-  "pattern", "placeholder", "poster", "preload", "radioGroup", "readOnly", "rel", "required", "role", "rows",
-  "rowSpan", "scrollLeft", "scrollTop", "selected", "size", "spellCheck", "src", "step", "style", "tabIndex",
-  "target", "title", "type", "value", "defaultValue", "width", "wmode"]);
+final Set<String> allowedSvgAttributes = new Set.from([
+  "cx",
+  "cy",
+  "d",
+  "fill",
+  "fx",
+  "fy",
+  "gradientTransform",
+  "gradientUnits",
+  "offset",
+  "points",
+  "r",
+  "rx",
+  "ry",
+  "spreadMethod",
+  "stopColor",
+  "stopOpacity",
+  "stroke",
+  "strokeLinecap",
+  "strokeWidth",
+  "transform",
+  "version",
+  "viewBox",
+  "x1",
+  "x2",
+  "x",
+  "y1",
+  "y2",
+  "y"
+]);
 
-final Set<String> allowedSvgAttributes = new Set.from(["cx", "cy", "d", "fill", "fx", "fy", "gradientTransform",
-  "gradientUnits", "offset", "points", "r", "rx", "ry",
-  "spreadMethod", "stopColor", "stopOpacity", "stroke", "strokeLinecap", "strokeWidth", "transform",
-  "version", "viewBox", "x1", "x2", "x", "y1", "y2", "y"]);
+final Set<String> allowedAttrsPrefixes = new Set.from(["data-", "aria-"]);

--- a/lib/src/dom/dom_elements.dart
+++ b/lib/src/dom/dom_elements.dart
@@ -14,7 +14,7 @@ ComponentDescriptionFactory _registerDomComponent(String tagname, {bool pair, bo
     /**
      * create default factory which create DomComponent
      */
-    factory = ({Map props, List<ComponentDescription> children}) => new DomComponent(props: props, children: children, tagName: tagname, pair: pair, svg: svg);;
+    factory = ({Map props, Iterable<ComponentDescription> children}) => new DomComponent(props: props, children: children, tagName: tagname, pair: pair, svg: svg);;
   }
 
   return registerComponent(factory);
@@ -25,7 +25,7 @@ _processChildren(dynamic children) {
   /**
    * iterage children to recognize string
    */
-  if (!(children is List) && children != null) {
+  if (!(children is Iterable) && children != null) {
     children = [children];
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.3+1
+version: 0.1.3+2
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.3+2
+version: 0.1.3+3
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.2
+version: 0.1.3
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.3
+version: 0.1.3+1
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.3+4
+version: 0.1.3+5
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,8 +8,8 @@ dependencies:
 dev_dependencies:
   browser: any
   meta: any
-  mock: any
+  mockito: any
   react: any
-  unittest: any
+  test: any
   useful: any
   webdriver: any

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: tiles
-version: 0.1.3+3
+version: 0.1.3+4
 author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ author: Jakuub Uhrik <jakuub@mail.com>
 description: The UI component library inspirated by Facebook React Javascript library.
 homepage: https://github.com/cleandart/tiles
 dependencies:
-  logging: any
+  logging: '>=0.9.1+1 <0.10.0'
 dev_dependencies:
   browser: any
   meta: any

--- a/test/all_browser.dart
+++ b/test/all_browser.dart
@@ -7,10 +7,8 @@ import 'browser/events_test.dart' as events;
 import 'browser/keys_test.dart' as keys;
 import 'browser/special_attributes_test.dart' as specialAttributes;
 import 'browser/elements.dart' as elements;
-import 'package:unittest/html_individual_config.dart';
 
 main () {
-  useHtmlIndividualConfiguration();
   mountComponent.main();
   mountLifecycle.main();
   updateComponent.main();

--- a/test/browser/elements.dart
+++ b/test/browser/elements.dart
@@ -1,6 +1,6 @@
 library tiles_browser_elements_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:tiles/tiles.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';

--- a/test/browser/events_test.dart
+++ b/test/browser/events_test.dart
@@ -29,16 +29,20 @@ main() {
     test("shold return html element for correct component", () {
       mountComponent(description, mountRoot);
 
-      expect(getElementForComponent(component), equals(mountRoot.children.first));
-
+      expect(
+          getElementForComponent(component), equals(mountRoot.children.first));
     });
 
     test("should controll type of event listener and throw if not correct", () {
-      expect(() => mountComponent(span(listeners: {"onClick": () {} }), mountRoot), throws);
+      expect(
+          () => mountComponent(span(listeners: {"onClick": () {}}), mountRoot),
+          throws);
     });
 
     test("should accept correct event listener", () {
-      expect(() => mountComponent(span(listeners: {"onClick": (Component component, Event event) {} }), mountRoot), isNot(throws));
+      expect(() => mountComponent(
+          span(listeners: {"onClick": (Component component, Event event) {}}),
+          mountRoot), isNot(throws));
     });
 
     test("should prevent default if component prevented default", () {
@@ -53,27 +57,23 @@ main() {
       }));
 
       mountRoot.children.first.click();
-
     });
 
     test("should not prevent default if component not prevented default", () {
-      mountComponent(span(listeners: {
-        "onClick": (Component component, Event event) {}
-      }), mountRoot);
+      mountComponent(
+          span(listeners: {"onClick": (Component component, Event event) {}}),
+          mountRoot);
 
       mountRoot.firstChild.on["click"].listen(expectAsync((Event event) {
         expect(event.defaultPrevented, isFalse);
       }));
 
       mountRoot.children.first.click();
-
     });
 
     test("should bubble event in correct order and only once", () {
       num order = 0;
-      mountComponent(span(props: {
-        "id": "wrapper",
-      }, children: span(listeners: {
+      mountComponent(span(props: {"id": "wrapper",}, children: span(listeners: {
         "onClick": expectAsync((Component component, Event event) {
           expect(order++, equals(0));
         }, count: 1)
@@ -84,19 +84,20 @@ main() {
       }), mountRoot);
 
       mountRoot.children.first.children.first.click();
-
     });
 
     test("should put correct component to event listeners", () {
       mountComponent(span(listeners: {
         "onClick": expectAsync((DomComponent component, Event event) {
           expect(component.tagName, equals("span"));
-          expect(getElementForComponent(component), equals(mountRoot.firstChild));
+          expect(
+              getElementForComponent(component), equals(mountRoot.firstChild));
         })
       }, children: div(listeners: {
         "onClick": expectAsync((DomComponent component, Event event) {
           expect(component.tagName, equals("div"));
-          expect(getElementForComponent(component), equals(mountRoot.firstChild.firstChild));
+          expect(getElementForComponent(component),
+              equals(mountRoot.firstChild.firstChild));
         })
       })), mountRoot);
 
@@ -104,10 +105,12 @@ main() {
     });
 
     test("should ignore stopPropagation on event", () {
-      mountComponent(span(listeners: {
-        "onClick": expectAsync((DomComponent component, Event event) {
-        }, count: 1)
-      }, children: div(listeners: {
+      mountComponent(span(
+          listeners: {
+        "onClick":
+            expectAsync((DomComponent component, Event event) {}, count: 1)
+      },
+          children: div(listeners: {
         "onClick": expectAsync((DomComponent component, Event event) {
           event.stopPropagation();
         }, count: 1)
@@ -117,40 +120,59 @@ main() {
     });
 
     test("should not propagate up when listener returns false", () {
-      mountComponent(span(listeners: {
-          "onClick": expectAsync((DomComponent component, Event event) {
-          }, count: 0)
-        }, children: div(listeners: {
-          "onClick": expectAsync((DomComponent component, Event event) {
-            return false;
-          }, count: 1)
-        })
-      ), mountRoot);
+      mountComponent(span(
+          listeners: {
+        "onClick":
+            expectAsync((DomComponent component, Event event) {}, count: 0)
+      },
+          children: div(listeners: {
+        "onClick": expectAsync((DomComponent component, Event event) {
+          return false;
+        }, count: 1)
+      })), mountRoot);
 
       mountRoot.children.first.children.first.click();
     });
 
-    test("should listen to events on custom component also, if props has [onEvent] in props", () {
+    test(
+        "should listen to events on custom component also, if props has [onEvent] in props",
+        () {
       ComponentMock componentMock = new ComponentMock();
       componentMock.when(callsTo("render")).alwaysReturn(div());
-      ComponentDescriptionFactory component = registerComponent(({props, children}) => componentMock);
+      ComponentDescriptionFactory component =
+          registerComponent(({props, children}) => componentMock);
 
-      mountComponent(component(listeners: {
-        "onClick": expectAsync((Component component, Event event) {
-        }, count: 1)
+      mountComponent(component(
+          listeners: {
+        "onClick": expectAsync((Component component, Event event) {}, count: 1)
       }), mountRoot);
 
       mountRoot.children.first.click();
-
     });
 
-    test("should not accept invalid event type", () {
+    test("should accept custom event type", () {
       expect(() {
-        mountComponent(div(listeners: {
-          "invalidListener": (Component component, Event event) => null
+        mountComponent(div(
+            listeners: {
+          "onCustom": (Component component, Event event) => null
         }), mountRoot);
-      }, throws);
+      }, isNot(throws));
     });
 
+    test("should listen also to custom events", () {
+      mountComponent(div(
+          listeners: {
+        "onCustomEvent": expectAsync((Component component, Event event) => null)
+      }), mountRoot);
+      mountRoot.children.first.dispatchEvent(new CustomEvent("customEvent"));
+    });
+
+    test("should listen accept event without 'on' prefix", () {
+      mountComponent(div(
+          listeners: {
+        "customEvent": expectAsync((Component component, Event event) => null)
+      }), mountRoot);
+      mountRoot.children.first.dispatchEvent(new CustomEvent("customEvent"));
+    });
   });
 }

--- a/test/browser/events_test.dart
+++ b/test/browser/events_test.dart
@@ -1,7 +1,7 @@
 library tiles_browser_events_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';
@@ -23,7 +23,7 @@ main() {
       component = new DomComponent(tagName: "span");
 
       description = new ComponentDescriptionMock();
-      description.when(callsTo("createComponent")).alwaysReturn(component);
+      when(description.createComponent()).thenReturn(component);
     });
 
     test("shold return html element for correct component", () {
@@ -138,7 +138,7 @@ main() {
         "should listen to events on custom component also, if props has [onEvent] in props",
         () {
       ComponentMock componentMock = new ComponentMock();
-      componentMock.when(callsTo("render")).alwaysReturn(div());
+      when(componentMock.render()).thenReturn(div());
       ComponentDescriptionFactory component =
           registerComponent(({props, children}) => componentMock);
 

--- a/test/browser/mount_component_test.dart
+++ b/test/browser/mount_component_test.dart
@@ -10,7 +10,8 @@ import '../mocks.dart';
 main() {
   group("(browser) (mountComponent)", () {
     Element mountRoot;
-    String imageSource = "http: //github.global.ssl.fastly.net/images/modules/logos_page/GitHub-Mark.png";
+    String imageSource =
+        "http: //github.global.ssl.fastly.net/images/modules/logos_page/GitHub-Mark.png";
 
     ComponentDescriptionMock descriptionWithSpan;
     ComponentDescriptionMock descriptionWithImage;
@@ -35,13 +36,17 @@ main() {
       componentWithSpan.when(callsTo("render")).alwaysReturn([span()]);
 
       descriptionWithSpan = new ComponentDescriptionMock();
-      descriptionWithSpan.when(callsTo("createComponent")).alwaysReturn(componentWithSpan);
+      descriptionWithSpan
+          .when(callsTo("createComponent"))
+          .alwaysReturn(componentWithSpan);
 
       componentWithImage = new ComponentMock();
       componentWithImage.when(callsTo("render")).alwaysReturn([img()]);
 
       descriptionWithImage = new ComponentDescriptionMock();
-      descriptionWithImage.when(callsTo("createComponent")).alwaysReturn(componentWithImage);
+      descriptionWithImage
+          .when(callsTo("createComponent"))
+          .alwaysReturn(componentWithImage);
 
       /**
        * uncomment to see what theese test do in browser
@@ -60,30 +65,35 @@ main() {
       expect(mountRoot.children.first.tagName, equals("DIV"));
     });
 
-
     test("should create div element if mount div()", () {
       mountComponent(div(props: {"class": "divclass"}), mountRoot);
 
       expect(mountRoot.children.length, equals(1));
-      expect(mountRoot.children.first.attributes["class"], contains("divclass"));
+      expect(
+          mountRoot.children.first.attributes["class"], contains("divclass"));
     });
 
-    test("should create 2 level children if passed 2 level of dom components", () {
+    test("should create 2 level children if passed 2 level of dom components",
+        () {
       mountComponent(div(children: div()), mountRoot);
 
       expect(mountRoot.children.length, equals(1));
       expect(mountRoot.children.first.children.length, equals(1));
     });
 
-    test("should create 3 level children if passed 2 level of dom components", () {
+    test("should create 3 level children if passed 2 level of dom components",
+        () {
       mountComponent(div(children: div(children: div())), mountRoot);
 
       expect(mountRoot.children.length, equals(1));
       expect(mountRoot.children.first.children.length, equals(1));
-      expect(mountRoot.children.first.children.first.children.length, equals(1));
+      expect(
+          mountRoot.children.first.children.first.children.length, equals(1));
     });
 
-    test("should create second level with 2 elements if passed such cescriptions", () {
+    test(
+        "should create second level with 2 elements if passed such cescriptions",
+        () {
       mountComponent(div(children: [div(), div()]), mountRoot);
 
       expect(mountRoot.children.length, equals(1));
@@ -99,10 +109,9 @@ main() {
     });
 
     test("should create image if image passed", () {
-      mountComponent(img(props: {
-        "src": imageSource,
-        "style": "height: 500px;",
-          }), mountRoot);
+      mountComponent(
+          img(props: {"src": imageSource, "style": "height: 500px;",}),
+          mountRoot);
 
       expect(mountRoot.children.length, equals(1));
 
@@ -119,8 +128,11 @@ main() {
       expect(mountRoot.children.first.children.isEmpty, isTrue);
     });
 
-    test("should write all children of children into element, if first level children was not dom components", () {
-      mountComponent(div(children: [descriptionWithSpan, descriptionWithImage]), mountRoot);
+    test(
+        "should write all children of children into element, if first level children was not dom components",
+        () {
+      mountComponent(div(children: [descriptionWithSpan, descriptionWithImage]),
+          mountRoot);
 
       expect(mountRoot.children.length, equals(1));
       Element el = mountRoot.children.first;
@@ -131,14 +143,17 @@ main() {
     });
 
     test("should clear element", () {
-      mountRoot.children.addAll([new DivElement(), new ImageElement(), new SpanElement()]);
+      mountRoot.children
+          .addAll([new DivElement(), new ImageElement(), new SpanElement()]);
 
       mountComponent(b(), mountRoot);
 
       expect(mountRoot.children.length, equals(1));
     });
 
-    test("if component have ref callback in props, it should be called with component instance when it is completely mounted", () {
+    test(
+        "if component have ref callback in props, it should be called with component instance when it is completely mounted",
+        () {
       var props = {};
 
       props["ref"] = expectAsync((Component component) {
@@ -158,7 +173,8 @@ main() {
       /**
        * just test, if no exception is thrown
        */
-      expect(() => mountComponent(descriptionWithSpan, mountRoot), isNot(throws));
+      expect(
+          () => mountComponent(descriptionWithSpan, mountRoot), isNot(throws));
     });
 
     test("should work with something weird in props ref", () {
@@ -166,7 +182,8 @@ main() {
       props["ref"] = new Mock();
       componentWithSpan.when(callsTo("get props")).alwaysReturn(props);
 
-      expect(() => mountComponent(descriptionWithSpan, mountRoot), isNot(throws));
+      expect(
+          () => mountComponent(descriptionWithSpan, mountRoot), isNot(throws));
     });
 
     test("should add only allowed attributes", () {
@@ -192,6 +209,71 @@ main() {
       expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
     });
 
+    group("(remount)", () {
+      var children1 = div(children: span(props: {"id": "id1"}));
+      var children2 = div(children: span(props: {"id": "id2"}));
+
+      Element divEl;
+      Element spanEl;
+
+      void _saveElements() {
+        divEl = mountRoot.children.first;
+        spanEl = divEl.children.first;
+      }
+
+      void checkRemount(Element mountRoot, Element divEl, Element spanEl) {
+        window.animationFrame.then(expectAsync((_) {
+          expect(mountRoot.children.first, equals(divEl));
+          expect(mountRoot.children.first.children.first, equals(spanEl));
+          expect(mountRoot.children.first.children.first.attributes["id"],
+              equals("id2"));
+        }));
+      }
+
+      ComponentDescription _createMockDescription() {
+        ComponentDescriptionMock description = new ComponentDescriptionMock();
+        ComponentMock component = new ComponentMock();
+
+        var factory = ({props, children}) => component;
+        var listeners = {"onClick": (_, __) {}};
+        var props = {"key": "value"};
+
+        description.when(callsTo("get factory")).alwaysReturn(factory);
+        description.when(callsTo("createComponent")).alwaysReturn(component);
+        description.when(callsTo("get props")).alwaysReturn(props);
+        description.when(callsTo("get listeners")).alwaysReturn(listeners);
+        description.when(callsTo("get children")).alwaysReturn(null);
+
+        component
+            .when(callsTo("render"))
+            .thenReturn(children1)
+            .thenReturn(children2);
+        
+        return description;
+      }
+
+      test("should only remount on second mount of the same dom component", () {
+        mountComponent(children1, mountRoot);
+
+        _saveElements();
+
+        mountComponent(children2, mountRoot);
+
+        checkRemount(mountRoot, divEl, spanEl);
+      });
+
+      test("should only remount on second mount of same custom component", () {
+        ComponentDescriptionMock description = _createMockDescription();
+
+        mountComponent(description, mountRoot);
+
+        _saveElements();
+
+        mountComponent(description, mountRoot);
+
+        checkRemount(mountRoot, divEl, spanEl);
+      });
+    });
   });
 
   group("(browser) (unmountComponent)", () {
@@ -201,7 +283,6 @@ main() {
       querySelector("body").append(mountRoot);
 
       mountComponent(div(), mountRoot);
-
     });
     test("should remove whole markup", () {
       unmountComponent(mountRoot);
@@ -212,27 +293,26 @@ main() {
       ComponentMock component = new ComponentMock();
       component.when(callsTo("render")).alwaysReturn([div()]);
 
-      ComponentDescriptionMock description= new ComponentDescriptionMock();
+      ComponentDescriptionMock description = new ComponentDescriptionMock();
       description.when(callsTo("createComponent")).alwaysReturn(component);
 
       mountComponent(description, mountRoot);
       unmountComponent(mountRoot);
 
       expect(mountRoot.children, isEmpty);
-
     });
 
     test("should remove relation between component and element on unmount", () {
       Component divComponent = new DomComponent(tagName: "div");
-      ComponentDescriptionMock divDescription= new ComponentDescriptionMock();
-      divDescription.when(callsTo("createComponent")).alwaysReturn(divComponent);
-
+      ComponentDescriptionMock divDescription = new ComponentDescriptionMock();
+      divDescription
+          .when(callsTo("createComponent"))
+          .alwaysReturn(divComponent);
 
       mountComponent(divDescription, mountRoot);
       unmountComponent(mountRoot);
 
       expect(getElementForComponent(divComponent), isNull);
-
     });
   });
 }

--- a/test/browser/mount_component_test.dart
+++ b/test/browser/mount_component_test.dart
@@ -1,7 +1,7 @@
 library tiles_mount_component_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';
@@ -33,20 +33,18 @@ main() {
        */
 
       componentWithSpan = new ComponentMock();
-      componentWithSpan.when(callsTo("render")).alwaysReturn([span()]);
+      when(componentWithSpan.render()).thenReturn([span()]);
 
       descriptionWithSpan = new ComponentDescriptionMock();
-      descriptionWithSpan
-          .when(callsTo("createComponent"))
-          .alwaysReturn(componentWithSpan);
+      when(descriptionWithSpan.createComponent())
+          .thenReturn(componentWithSpan);
 
       componentWithImage = new ComponentMock();
-      componentWithImage.when(callsTo("render")).alwaysReturn([img()]);
+      when(componentWithImage.render()).thenReturn([img()]);
 
       descriptionWithImage = new ComponentDescriptionMock();
-      descriptionWithImage
-          .when(callsTo("createComponent"))
-          .alwaysReturn(componentWithImage);
+      when(descriptionWithImage.createComponent())
+          .thenReturn(componentWithImage);
 
       /**
        * uncomment to see what theese test do in browser
@@ -160,7 +158,7 @@ main() {
         expect(component, equals(componentWithSpan));
       });
 
-      componentWithSpan.when(callsTo("get props")).alwaysReturn(props);
+      when(componentWithSpan.props).thenReturn(props);
 
       mountComponent(descriptionWithSpan, mountRoot);
       expect(descriptionWithSpan.createComponent(), equals(componentWithSpan));
@@ -168,7 +166,7 @@ main() {
     });
 
     test("should work if component not have props", () {
-      componentWithSpan.when(callsTo("get props")).alwaysReturn(null);
+      when(componentWithSpan.props).thenReturn(null);
 
       /**
        * just test, if no exception is thrown
@@ -180,7 +178,7 @@ main() {
     test("should work with something weird in props ref", () {
       var props = {};
       props["ref"] = new Mock();
-      componentWithSpan.when(callsTo("get props")).alwaysReturn(props);
+      when(componentWithSpan.props).thenReturn(props);
 
       expect(
           () => mountComponent(descriptionWithSpan, mountRoot), isNot(throws));
@@ -244,26 +242,30 @@ main() {
         }));
       }
 
+      ComponentMock component;
       ComponentDescription _createMockDescription() {
         ComponentDescriptionMock description = new ComponentDescriptionMock();
-        ComponentMock component = new ComponentMock();
+        component = new ComponentMock();
 
         var factory = ({props, children}) => component;
         var listeners = {"onClick": (_, __) {}};
         var props = {"key": "value"};
 
-        description.when(callsTo("get factory")).alwaysReturn(factory);
-        description.when(callsTo("createComponent")).alwaysReturn(component);
-        description.when(callsTo("get props")).alwaysReturn(props);
-        description.when(callsTo("get listeners")).alwaysReturn(listeners);
-        description.when(callsTo("get children")).alwaysReturn(null);
+        when(description.factory).thenReturn(factory);
+        when(description.createComponent()).thenReturn(component);
+        when(description.props).thenReturn(props);
+        when(description.listeners).thenReturn(listeners);
+        when(description.children).thenReturn(null);
 
-        component
-            .when(callsTo("render"))
-            .thenReturn(children1)
-            .thenReturn(children2);
+        when(component.render())
+            .thenReturn(children1);
         
         return description;
+      }
+      
+      void nextRender() {
+        when(component.render())
+            .thenReturn(children2);
       }
 
       test("should only remount on second mount of the same dom component", () {
@@ -282,6 +284,7 @@ main() {
         mountComponent(description, mountRoot);
 
         _saveElements();
+        nextRender();
 
         mountComponent(description, mountRoot);
 
@@ -305,10 +308,10 @@ main() {
 
     test("should remove whole markup when custom componet was mounted", () {
       ComponentMock component = new ComponentMock();
-      component.when(callsTo("render")).alwaysReturn([div()]);
+      when(component.render()).thenReturn([div()]);
 
       ComponentDescriptionMock description = new ComponentDescriptionMock();
-      description.when(callsTo("createComponent")).alwaysReturn(component);
+      when(description.createComponent()).thenReturn(component);
 
       mountComponent(description, mountRoot);
       unmountComponent(mountRoot);
@@ -319,9 +322,8 @@ main() {
     test("should remove relation between component and element on unmount", () {
       Component divComponent = new DomComponent(tagName: "div");
       ComponentDescriptionMock divDescription = new ComponentDescriptionMock();
-      divDescription
-          .when(callsTo("createComponent"))
-          .alwaysReturn(divComponent);
+      when(divDescription.createComponent())
+          .thenReturn(divComponent);
 
       mountComponent(divDescription, mountRoot);
       unmountComponent(mountRoot);

--- a/test/browser/mount_component_test.dart
+++ b/test/browser/mount_component_test.dart
@@ -208,6 +208,20 @@ main() {
       expect(mountRoot.children.first.attributes.containsKey("id"), isFalse);
       expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
     });
+    
+    test("should add attributes with allowed prefixes", () {
+      var props = {"aria-something": "aria", "data-somethingelse": "data", "wrong-else": "wrong"};
+
+      mountComponent(div(props: props), mountRoot);
+
+      expect(mountRoot.children.first.attributes.containsKey("aria-something"), isTrue);
+      expect(mountRoot.children.first.attributes["aria-something"], equals("aria"));
+      
+      expect(mountRoot.children.first.attributes.containsKey("data-somethingelse"), isTrue);
+      expect(mountRoot.children.first.attributes["data-somethingelse"], equals("data"));
+      
+      expect(mountRoot.children.first.attributes.containsKey("wrong-else"), isFalse);
+    });
 
     group("(remount)", () {
       var children1 = div(children: span(props: {"id": "id1"}));

--- a/test/browser/mount_component_test.dart
+++ b/test/browser/mount_component_test.dart
@@ -328,5 +328,20 @@ main() {
 
       expect(getElementForComponent(divComponent), isNull);
     });
+    
+    test("should dangorously insert inner HTML", () {
+      mountRoot = new DivElement();
+      mountComponent(div(props:{"dangerouslySetInnerHTML": "<span class='cl'>hello</span>"}), mountRoot);
+      
+      expect(mountRoot.children.first.children.first is SpanElement, isTrue);
+    });
+    
+    test("should throw if want to set inner html and also have childre", () {
+      mountRoot = new DivElement();
+
+      expect(() {
+        mountComponent(div(children: "hello", props:{"dangerouslySetInnerHTML": "<span class='cl'>hello</span>"}), mountRoot);
+      }, throws);
+    });
   });
 }

--- a/test/browser/mount_lifecycle_test.dart
+++ b/test/browser/mount_lifecycle_test.dart
@@ -1,7 +1,7 @@
 library tiles_mount_lifecycle_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';
 import 'dart:async';
@@ -9,10 +9,12 @@ import '../mocks.dart';
 
 main() {
   group("(browser) (LifeCycle)", () {
+    
     Element mountRoot;
 
     ComponentDescriptionMock description;
     ComponentMock component;
+    StreamController controller;
 
     try {
       initTilesBrowserConfiguration();
@@ -29,119 +31,143 @@ main() {
        */
 
       component = new ComponentMock();
-      component.when(callsTo("render")).alwaysReturn(null);
-      component.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      when(component.render).thenReturn(null);
+      when(component.shouldUpdate).thenReturn(true);
 
       description = new ComponentDescriptionMock();
-      description.when(callsTo("createComponent")).alwaysReturn(component);
+      when(description.createComponent()).thenReturn(component);
 
-      StreamController controller = new StreamController();
-      component.when(callsTo("get needUpdate"))
-        .alwaysReturn(controller.stream);
-
-      component.when(callsTo("redraw"))
-        .alwaysCall(([bool what]) => controller.add(what));
+      controller = new StreamController();
+      when(component.needUpdate).thenReturn(controller.stream);
 
       querySelector("body").append(mountRoot);
     });
 
     test("should call didMount after mount", () {
       mountComponent(description, mountRoot);
-      component.getLogs(callsTo("render")).verify(happenedOnce);
-      component.getLogs(callsTo("didMount")).verify(happenedOnce);
+      verify(component.render());
+      verify(component.didMount());
     });
 
-    test("should call shouldUpdate, render and didUpdate when node is marked as dirty", () {
+    test(
+        "should call shouldUpdate, render and didUpdate when node is marked as dirty",
+        () {
       mountComponent(description, mountRoot);
 
-      component.redraw();
-      component.clearLogs();
+      clearInteractions(component);
+      controller.add(null);
 
       window.animationFrame.then(expectAsync((val) {
-        component.getLogs(callsTo("shouldUpdate")).verify(happenedOnce);
+        verifyNever(component.willReceiveProps(any));
+        verify(component.shouldUpdate(any, any));
+        verify(component.render());
 
-        component.getLogs(callsTo("willReceiveProps")).verify(neverHappened);
-        component.getLogs(callsTo("render")).verify(happenedOnce);
-
-        component.getLogs(callsTo("didUpdate")).verify(happenedOnce);
+        verify(component.didUpdate());
       }));
     });
 
     test("should call willUnmount when it is unmounted", () {
       mountComponent(description, mountRoot);
 
-      component.clearLogs();
+      clearInteractions(component);
       unmountComponent(mountRoot);
 
-      component.getLogs(callsTo("shouldUpdate")).verify(neverHappened);
-      component.getLogs(callsTo("willReceiveProps")).verify(neverHappened);
-      component.getLogs(callsTo("render")).verify(neverHappened);
-      component.getLogs(callsTo("didUpdate")).verify(neverHappened);
-
-      component.getLogs(callsTo("willUnmount")).verify(happenedOnce);
+      verify(component.willUnmount());
+      
+      verifyNever(component.shouldUpdate(any, any));
+      verifyNever(component.willReceiveProps(any));
+      verifyNever(component.render());
+      verifyNever(component.didUpdate());
     });
 
     group("(core complex)", () {
+      Map<dynamic, StreamController> controllers;
       ComponentMock c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11;
-      ComponentDescriptionMock dc1, dc2, dc3, dc4, dc5, dc6, dc7, dc8, dc9, dc10, dc11;
+      ComponentDescriptionMock dc1,
+          dc2,
+          dc3,
+          dc4,
+          dc5,
+          dc6,
+          dc7,
+          dc8,
+          dc9,
+          dc10,
+          dc11;
 
-      createDefaultDescription (ComponentMock component) {
+      createDefaultDescription(ComponentMock component) {
         ComponentDescriptionMock description = new ComponentDescriptionMock();
-        description.when(callsTo("createComponent")).alwaysReturn(component);
+        when(description.createComponent()).thenReturn(component);
         return description;
       }
 
-      createCleanComponent () {
+      createCleanComponent() {
         ComponentMock component = new ComponentMock();
 
-        StreamController controller = new StreamController();
-        component.when(callsTo("get needUpdate"))
-          .alwaysReturn(controller.stream);
+        StreamController controller = new StreamController(sync: true);
+        when(component.needUpdate).thenReturn(controller.stream);
 
-        component.when(callsTo("redraw"))
-          .alwaysCall(([bool what]) => controller.add(what));
+        controllers[component] = controller;
 
         return component;
       }
 
-      createDefaultComponent ([List<ComponentDescriptionMock> whatToRender]) {
+      createDefaultComponent([List<ComponentDescriptionMock> whatToRender]) {
         ComponentMock component = createCleanComponent();
 
-        component.when(callsTo("shouldUpdate")).alwaysReturn(true);
+        when(component.shouldUpdate(any, any)).thenReturn(true);
 
-        component.when(callsTo("render")).alwaysReturn(whatToRender);
+        when(component.render()).thenReturn(whatToRender);
 
         return component;
       }
 
-      clearLogs() {
-        c1.clearLogs();
-        c2.clearLogs();
-        c3.clearLogs();
-        c4.clearLogs();
-        c5.clearLogs();
-        c6.clearLogs();
-        c7.clearLogs();
-        c8.clearLogs();
-        c9.clearLogs();
-        c10.clearLogs();
-        c11.clearLogs();
+      resetAll() {
+        clearInteractions(c1);
+        clearInteractions(c2);
+        clearInteractions(c3);
+        clearInteractions(c4);
+        clearInteractions(c5);
+        clearInteractions(c6);
+        clearInteractions(c7);
+        clearInteractions(c8);
+        clearInteractions(c9);
+        clearInteractions(c10);
+        clearInteractions(c11);
       }
 
-      shouldHappened(List<ComponentMock> components, String what, expect) {
+      const String ONCE = "ONCE";
+      const String NEVER = "NEVER";
+      shouldHappened(Iterable<ComponentMock> components, String what, String expect) {
         for (component in components) {
-          component.getLogs(callsTo(what)).verify(expect);
+          var verif = expect == ONCE ? verify : verifyNever;
+          switch (what) {
+            case "render":
+              verif(component.render());
+              break;
+            case "didUpdate":
+              verif(component.didUpdate());
+              break;
+            case "didMount":
+              verif(component.didMount());
+              break;
+            case "willUnmount":
+              verif(component.willUnmount());
+              break;
+          }
         }
       }
 
-      shouldHappenedOnce(String what) {
-        shouldHappened([c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11], what, happenedOnce);
+      shouldHappenedOncee(String what) {
+        shouldHappened(
+            [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11].reversed, what, ONCE);
       }
-      shouldNeverHappened(String what) {
-        shouldHappened([c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11], what, neverHappened);
+      shouldNeverHappenedd(String what) {
+        shouldHappened(
+            [c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11], what, NEVER);
       }
 
-      createStructure () {
+      createStructure() {
         /**
          * Structure
          *            c1
@@ -152,11 +178,16 @@ main() {
          *     /     /  \      /  \
          *   c7     c8   c9   c10  c11
          */
-        c7 = createDefaultComponent();
-        c8 = createDefaultComponent();
-        c9 = createDefaultComponent();
-        c10 = createDefaultComponent();
         c11 = createDefaultComponent();
+        named(c11, name: "c11");
+        c10 = createDefaultComponent();
+        named(c10, name: "c10");
+        c9 = createDefaultComponent();
+        named(c9, name: "c9");
+        c8 = createDefaultComponent();
+        named(c8, name: "c8");
+        c7 = createDefaultComponent();
+        named(c7, name: "c7");
 
         dc7 = createDefaultDescription(c7);
         dc8 = createDefaultDescription(c8);
@@ -164,62 +195,78 @@ main() {
         dc10 = createDefaultDescription(c10);
         dc11 = createDefaultDescription(c11);
 
-        c4 = createDefaultComponent([dc7]);
-        c5 = createDefaultComponent([dc8, dc9]);
         c6 = createDefaultComponent([dc10, dc11]);
+        named(c6, name: "c6");
+        c5 = createDefaultComponent([dc8, dc9]);
+        named(c5, name: "c5");
+        c4 = createDefaultComponent([dc7]);
+        named(c4, name: "c4");
 
         dc4 = createDefaultDescription(c4);
         dc5 = createDefaultDescription(c5);
         dc6 = createDefaultDescription(c6);
 
-        c2 = createDefaultComponent([dc4, dc5]);
         c3 = createDefaultComponent([dc6]);
+        named(c3, name: "c3");
+        c2 = createDefaultComponent([dc4, dc5]);
+        named(c2, name: "c2");
         dc2 = createDefaultDescription(c2);
         dc3 = createDefaultDescription(c3);
 
         c1 = createDefaultComponent([dc2, dc3]);
+        named(c1, name: "c1");
         dc1 = createDefaultDescription(c1);
+        
       }
 
-      setup() {
+      setUp(() {
+        controllers = {};
         createStructure();
         mountComponent(dc1, mountRoot);
-
-      }
-      setUp(setup);
-
-
+      });
+      
       test("should be every render called once in more complex structure", () {
-        shouldHappenedOnce("render");
+        shouldHappenedOncee("render");
       });
 
       test("should call didMount on every component", () {
-        shouldHappenedOnce("didMount");
+        shouldHappenedOncee("didMount");
       });
 
       test("should call didUpdate for every updated node", () {
-        clearLogs();
-        c1.redraw();
+        controllers[c1].add(true);
+        resetAll();
         window.animationFrame.then(expectAsync((data) {
-          shouldHappenedOnce("didUpdate");
+            shouldHappenedOncee("didUpdate");
         }));
       });
 
       test("shold call didUpdate only under dirty node", () {
-        clearLogs();
+        resetAll();
 
-        c2.redraw();
+        controllers[c2].add(true);
         window.animationFrame.then(expectAsync((data) {
-          shouldHappened([c1, c3, c6, c10, c11], "didUpdate", neverHappened);
-          shouldHappened([c2, c4, c5, c7, c8, c9], "didUpdate", happenedOnce);
+          shouldHappened([c1, c3, c6, c10, c11], "didUpdate", NEVER);
+          shouldHappened([c2, c4, c5, c7, c8, c9], "didUpdate", ONCE);
         }));
       });
 
       test("should unmount everything on unmountComponent", () {
         unmountComponent(mountRoot);
 
-        shouldHappened([c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11], "willUnmount", happenedOnce);
-
+        shouldHappened([
+          c1,
+          c2,
+          c3,
+          c4,
+          c5,
+          c6,
+          c7,
+          c8,
+          c9,
+          c10,
+          c11
+        ], "willUnmount", ONCE);
       });
 
       test("should unmount whole subtree when one component remove child", () {
@@ -227,53 +274,53 @@ main() {
 
         createStructure();
         c1 = createCleanComponent();
-        c1.when(callsTo("shouldUpdate")).alwaysReturn(true);
-        c1.when(callsTo("render"))
-          .thenReturn([dc2, dc3])
-          .thenReturn([dc2]);
+        when(c1.shouldUpdate(any, any)).thenReturn(true);
+        when(c1.render()).thenReturn([dc2, dc3]).thenReturn([dc2]);
         dc1 = createDefaultDescription(c1);
         mountComponent(dc1, mountRoot);
+        
+        when(c1.render()).thenReturn([dc2]);
 
-        shouldHappenedOnce("render");
-        clearLogs();
+        shouldHappenedOncee("render");
+        resetAll();
 
-        c1.redraw();
-
+        controllers[c1].add(true);
         window.animationFrame.then(expectAsync((data) {
           var stilMounted = [c1, c2, c4, c5, c7, c8, c9];
-          var unmounted = [c3, c6,c10, c11];
-          shouldHappened(stilMounted, "didUpdate", happenedOnce);
-          shouldHappened(unmounted, "didUpdate", neverHappened);
-          shouldHappened(stilMounted, "willUnmount", neverHappened);
-          shouldHappened(unmounted, "willUnmount", happenedOnce);
+          var unmounted = [c3, c6, c10, c11];
+          shouldHappened(stilMounted, "didUpdate", ONCE);
+          shouldHappened(unmounted, "didUpdate", NEVER);
+          shouldHappened(stilMounted, "willUnmount", NEVER);
+          shouldHappened(unmounted, "willUnmount", ONCE);
         }));
-
       });
-      test("should didMount new whole subtree when one component add child child", () {
+      test("should didMount new whole subtree when one component add child child",() {
         unmountComponent(mountRoot);
 
         createStructure();
+        var controller = controllers[c1];
+        
         c1 = createCleanComponent();
-        c1.when(callsTo("shouldUpdate")).alwaysReturn(true);
-        c1.when(callsTo("render"))
-          .thenReturn([dc2])
-          .thenReturn([dc2, dc3]);
+        when(c1.shouldUpdate(any, any)).thenReturn(true);
+        when(c1.render()).thenReturn([dc2]);
+        when(c1.needUpdate).thenReturn(controller.stream);
+        
         dc1 = createDefaultDescription(c1);
+        
         mountComponent(dc1, mountRoot);
 
-        clearLogs();
-
-        c1.redraw();
+        when(c1.render()).thenReturn([dc2, dc3]);
+        resetAll();
+        controller.add(true);
 
         window.animationFrame.then(expectAsync((data) {
           var stilMounted = [c1, c2, c4, c5, c7, c8, c9];
-          var mounted = [c3, c6,c10, c11];
-          shouldHappened(stilMounted, "didUpdate", happenedOnce);
-          shouldHappened(mounted, "didUpdate", neverHappened);
-          shouldHappened(stilMounted, "didMount", neverHappened);
-          shouldHappened(mounted, "didMount", happenedOnce);
+          var mounted = [c3, c6, c10, c11];
+          shouldHappened(stilMounted, "didUpdate", ONCE);
+          shouldHappened(mounted, "didUpdate", NEVER);
+          shouldHappened(stilMounted, "didMount", NEVER);
+          shouldHappened(mounted, "didMount", ONCE);
         }));
-
       });
       /**
        * Structure
@@ -285,7 +332,6 @@ main() {
        *     /     /  \      /  \
        *   c7     c8   c9   c10  c11
        */
-
 
     });
   });

--- a/test/browser/special_attributes_test.dart
+++ b/test/browser/special_attributes_test.dart
@@ -1,7 +1,7 @@
 library tiles_special_attributes_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';
@@ -38,23 +38,19 @@ main() {
       component = new ComponentMock();
 
       description = new ComponentDescriptionMock();
-      description.when(callsTo("createComponent"))
-        .alwaysReturn(component);
+      when(description.createComponent()).thenReturn(component);
 
       /**
        * prepare controller which simulates component redraw
        */
       controller = new StreamController();
-      component.when(callsTo("get needUpdate"))
-        .alwaysReturn(controller.stream);
+      when(component.needUpdate).thenReturn(controller.stream);
 
       /**
        * prepare component mock redraw method
        * to work intuitively to easily writable test
        */
-      component.when(callsTo("redraw"))
-        .alwaysCall(([bool what]) => controller.add(what));
-      component.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      when(component.shouldUpdate(any, any)).thenReturn(true);
 
       /**
        * uncomment to see what theese test do in browser
@@ -63,9 +59,8 @@ main() {
     });
 
     test("should set value if seted attribute value", () {
-      component.when(callsTo("render"))
-        .thenReturn(input(props: {value: value1}))
-        .thenReturn(input(props: {value: value2}));
+      when(component.render())
+          .thenReturn(input(props: {value: value1}));
 
       mountComponent(description, mountRoot);
 
@@ -74,17 +69,21 @@ main() {
 
       element.value = elseValue;
 
-      component.redraw();
+      controller.add(null);
+      when(component.render())
+          .thenReturn(input(props: {value: value2}));
 
       window.animationFrame.then(expectAsync((_) {
         expect(element.value, equals(value2));
       }));
     });
 
-    test("should set default value and not replace real value if seted attribute defaultValue", () {
-      component.when(callsTo("render"))
-        .thenReturn(input(props: {defaultValue: value1}))
-        .thenReturn(input(props: {defaultValue: value2}));
+    test(
+        "should set default value and not replace real value if seted attribute defaultValue",
+        () {
+      when(component.render())
+          .thenReturn(input(props: {defaultValue: value1}))
+          .thenReturn(input(props: {defaultValue: value2}));
 
       mountComponent(description, mountRoot);
 
@@ -93,7 +92,7 @@ main() {
 
       element.value = elseValue;
 
-      component.redraw();
+      controller.add(null);
 
       window.animationFrame.then(expectAsync((_) {
         expect(element.value, equals(elseValue));
@@ -101,9 +100,9 @@ main() {
     });
 
     test('should add value into textarea from "value" prop', () {
-      component.when(callsTo("render"))
-        .thenReturn(textarea(props: {value: value1}, children: div()))
-        .thenReturn(textarea(props: {value: value2}));
+      when(component.render())
+          .thenReturn(textarea(props: {value: value1}, children: div()))
+          .thenReturn(textarea(props: {value: value2}));
 
       mountComponent(description, mountRoot);
 
@@ -112,9 +111,8 @@ main() {
     });
 
     test('should update value in textarea from "value" prop', () {
-      component.when(callsTo("render"))
-        .thenReturn(textarea(props: {value: value1}, children: div()))
-        .thenReturn(textarea(props: {value: value2}));
+      when(component.render())
+          .thenReturn(textarea(props: {value: value1}, children: div()));
 
       mountComponent(description, mountRoot);
 
@@ -123,13 +121,13 @@ main() {
 
       element.value = elseValue;
 
-      component.redraw();
+      controller.add(null);
+      when(component.render())
+          .thenReturn(textarea(props: {value: value2}));
 
       window.animationFrame.then(expectAsync((_) {
         expect(element.value, equals(value2));
       }));
     });
-
   });
 }
-

--- a/test/browser/update_component_test.dart
+++ b/test/browser/update_component_test.dart
@@ -552,6 +552,82 @@ main() {
         expect(text.text, equals(text2));
       }));
     });
+    
+    group("(dangerouslySetInnerHTML)", () {
+      test("should update dangerously seted inner HTML", () {
+        String text1 = "hello",
+            text2 = "aloha";
+        component.when(callsTo("render"))
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}))
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
+
+        mountComponent(description, mountRoot);
+
+        Text text = mountRoot.firstChild.firstChild;
+        expect(text is Text, isTrue);
+        expect(text.text, equals(text1));
+
+        component.redraw();
+
+        window.animationFrame.then(expectAsync((data) {
+          text = mountRoot.firstChild.firstChild;
+          expect(text is Text, isTrue);
+          expect(text.text, equals(text2));
+        }));
+        
+      });
+      
+      test("should update dangerously seted more complex inner HTML", () {
+        String text1 = "<span>hello</span><div>helloo</div>",
+            text2 = "<div>aloha</div><span>alooha</span>";
+        component.when(callsTo("render"))
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}))
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
+
+        mountComponent(description, mountRoot);
+
+        Element divel = mountRoot.firstChild.lastChild;
+        Element spanel = mountRoot.firstChild.firstChild;
+        expect(divel is DivElement, isTrue);
+        expect(spanel is SpanElement, isTrue);
+        expect(divel.text, equals("helloo"));
+        expect(spanel.text, equals("hello"));
+
+        component.redraw();
+
+        window.animationFrame.then(expectAsync((data) {
+          divel = mountRoot.firstChild.firstChild;
+          spanel = mountRoot.firstChild.lastChild;
+          expect(divel is DivElement, isTrue);
+          expect(spanel is SpanElement, isTrue);
+          expect(divel.text, equals("aloha"));
+          expect(spanel.text, equals("alooha"));
+
+        }));
+        
+      });      
+
+      test("should create component dangerously seted inner HTML", () {
+        String text = "aloha";
+        component.when(callsTo("render"))
+          .thenReturn(div())
+          .thenReturn(div(children: div(props: {"dangerouslySetInnerHTML": text})));
+
+        mountComponent(description, mountRoot);
+
+        Text innerElement = mountRoot.firstChild.firstChild;
+        expect(innerElement, isNull);
+
+        component.redraw();
+
+        window.animationFrame.then(expectAsync((data) {
+          innerElement = mountRoot.firstChild.firstChild.firstChild;
+          expect(innerElement is Text, isTrue);
+          expect(innerElement.text, equals(text));
+        }));
+      });
+      
+    });
 
   });
 }

--- a/test/browser/update_component_test.dart
+++ b/test/browser/update_component_test.dart
@@ -1,7 +1,7 @@
 library tiles_update_component_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import 'package:tiles/tiles_browser.dart';
 import 'dart:html';
@@ -33,23 +33,21 @@ main() {
       component = new ComponentMock();
 
       description = new ComponentDescriptionMock();
-      description.when(callsTo("createComponent"))
-        .alwaysReturn(component);
+      when(description.createComponent())
+        .thenReturn(component);
 
       /**
        * prepare controller which simulates component redraw
        */
       controller = new StreamController();
-      component.when(callsTo("get needUpdate"))
-        .alwaysReturn(controller.stream);
+      when(component.needUpdate)
+        .thenReturn(controller.stream);
 
       /**
        * prepare component mock redraw method
        * to work intuitively to easily writable test
        */
-      component.when(callsTo("redraw"))
-        .alwaysCall(([bool what]) => controller.add(what));
-      component.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      when(component.shouldUpdate).thenReturn(true);
 
       /**
        * uncomment to see what theese test do in browser
@@ -58,13 +56,14 @@ main() {
     });
 
     test("should rerender after component called redraw", () {
-      component.when(callsTo("render"))
-        .thenReturn([span()])
-        .thenReturn([img()]);
+      when(component.render())
+        .thenReturn([span()]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+      when(component.render())
+        .thenReturn([img()]);
+      controller.add(true);
 
       window.animationFrame.then(expectAsync((something) {
         expect(mountRoot.children.length, equals(1));
@@ -73,13 +72,8 @@ main() {
     });
 
     test("should replace only inner element, which should be replaced", () {
-      component.when(callsTo("render"))
-        .thenCall(() {
-          return [div(children: span()), div()];
-        })
-        .thenCall(() {
-          return [div(children: img()), div()];
-        });
+      when(component.render())
+        .thenReturn([div(children: span()), div()]);
 
       mountComponent(description, mountRoot);
 
@@ -89,7 +83,9 @@ main() {
 
       var dd = mountRoot.childNodes.first;
 
-      component.redraw();
+      when(component.render())
+        .thenReturn([div(children: img()), div()]);
+      controller.add(true);
 
       window.animationFrame.then(expectAsync((something) {
         expect(mountRoot.children.length, equals(2));
@@ -100,17 +96,14 @@ main() {
     });
 
     test("should replace element at place", () {
-      component.when(callsTo("render"))
-        .thenCall(() {
-          return [div(children: [span(), span()])];
-        })
-        .thenCall(() {
-          return [div(children: [img(), span()])];
-        });
+      when(component.render())
+        .thenReturn([div(children: [span(), span()])]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+      when(component.render())
+        .thenReturn([div(children: [img(), span()])]);
+      controller.add(true);
 
       Element sp = mountRoot.children.first.children.last;
 
@@ -121,17 +114,14 @@ main() {
     });
 
     test("should replace 2 elements at place", () {
-      component.when(callsTo("render"))
-        .thenCall(() {
-          return [div(children: [span(), span(), span()])];
-        })
-        .thenCall(() {
-          return [div(children: [div(), img(), span()])];
-        });
+      when(component.render())
+        .thenReturn([div(children: [span(), span(), span()])]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+      when(component.render())
+        .thenReturn([div(children: [div(), img(), span()])]);
+      controller.add(true);
 
       Element sp = mountRoot.children.first.children.last;
 
@@ -143,9 +133,8 @@ main() {
     });
 
     test("should replace elements properly in more complicated example", () {
-      component.when(callsTo("render"))
-        .thenCall(() {
-          return [div(children: [
+      when(component.render())
+        .thenReturn([div(children: [
                     span(),
                     span(),
                     span(children: div(children: [
@@ -155,10 +144,12 @@ main() {
                         a()
                       ])),
                     span()
-                 ])];
-        })
-        .thenCall(() {
-          return [div(children: [
+                 ])]);
+
+      mountComponent(description, mountRoot);
+
+      when(component.render())
+        .thenReturn([div(children: [
                     div(),
                     img(),
                     span(children: div(children: [
@@ -168,12 +159,8 @@ main() {
                         b()
                       ])),
                     form()
-                ])];
-        });
-
-      mountComponent(description, mountRoot);
-
-      component.redraw();
+                ])]);
+      controller.add(true);
 
       Element sp = mountRoot.children.first.children[2];
 
@@ -202,16 +189,17 @@ main() {
           id = "myId";
       int height = 12;
 
-      component.when(callsTo("render"))
-        .thenReturn([span(props: {"class": myClass, "id": id})])
-        .thenReturn([span(props: {"class": myOtherClass, "height": height})]);
+      when(component.render())
+        .thenReturn([span(props: {"class": myClass, "id": id})]);
 
       mountComponent(description, mountRoot);
 
       expect(mountRoot.children.first.getAttribute("class"), equals(myClass));
       expect(mountRoot.children.first.getAttribute("id"), equals(id));
       expect(mountRoot.children.first.attributes.containsKey("height"), isFalse, reason: "should not contain height");
-      component.redraw();
+      controller.add(true);
+      when(component.render())
+        .thenReturn([span(props: {"class": myOtherClass, "height": height})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.getAttribute("class"), equals(myOtherClass), reason: "class should change");
@@ -224,13 +212,14 @@ main() {
       /**
        * one html attribute, one svg and one non of them
        */
-      component.when(callsTo("render"))
-        .thenReturn([span(props: {})])
-        .thenReturn([span(props: {"class": "class", "text": "text", "crap": "crap"})]);
+      when(component.render())
+        .thenReturn([span(props: {})]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+      controller.add(true);
+      when(component.render())
+        .thenReturn([span(props: {"class": "class", "text": "text", "crap": "crap"})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
@@ -243,13 +232,14 @@ main() {
       /**
        * one html attribute, one svg and one non of them
        */
-      component.when(callsTo("render"))
-        .thenReturn([span(props: {"id": "id", "d": "d", "crap": "crap"})])
-        .thenReturn([span(props: {"id": "id2", "d": "d2", "crap": "crap2"})]);
+      when(component.render())
+        .thenReturn([span(props: {"id": "id", "d": "d", "crap": "crap"})]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+      controller.add(true);
+      when(component.render())
+        .thenReturn([span(props: {"id": "id2", "d": "d2", "crap": "crap2"})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
@@ -262,13 +252,14 @@ main() {
       /**
        * one html attribute, one svg and one non of them
        */
-      component.when(callsTo("render"))
-        .thenReturn([svg(props: {})])
-        .thenReturn([svg(props: {"id": "id2", "d": "d2", "crap": "crap"})]);
+      when(component.render())
+        .thenReturn([svg(props: {})]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+    controller.add(true);
+    when(component.render())
+      .thenReturn([svg(props: {"id": "id2", "d": "d2", "crap": "crap"})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
@@ -281,13 +272,14 @@ main() {
       /**
        * one html attribute, one svg and one non of them
        */
-      component.when(callsTo("render"))
-        .thenReturn([svg(props: {"id": "id", "d": "d", "crap": "crap"})])
-        .thenReturn([svg(props: {"id": "id2", "d": "d2", "crap": "crap2"})]);
+      when(component.render())
+        .thenReturn([svg(props: {"id": "id", "d": "d", "crap": "crap"})]);
 
       mountComponent(description, mountRoot);
 
-      component.redraw();
+    controller.add(true);
+      when(component.render())
+        .thenReturn([svg(props: {"id": "id2", "d": "d2", "crap": "crap2"})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.attributes.containsKey("crap"), isFalse);
@@ -300,15 +292,16 @@ main() {
       String myClass = "myclass";
       int height = 12;
 
-      component.when(callsTo("render"))
-        .thenReturn([span()])
-        .thenReturn([span(props: {"class": myClass, "height": height})]);
+      when(component.render())
+        .thenReturn([span()]);
 
       mountComponent(description, mountRoot);
 
       expect(mountRoot.children.first.attributes, isEmpty);
 
-      component.redraw();
+    controller.add(true);
+      when(component.render())
+        .thenReturn([span(props: {"class": myClass, "height": height})]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.getAttribute("class"), equals(myClass), reason: "class should change");
@@ -320,16 +313,17 @@ main() {
       String myClass = "myclass";
       int height = 12;
 
-      component.when(callsTo("render"))
-        .thenReturn([span(props: {"class": myClass, "height": height})])
-        .thenReturn([span()]);
+      when(component.render())
+        .thenReturn([span(props: {"class": myClass, "height": height})]);
 
       mountComponent(description, mountRoot);
 
       expect(mountRoot.children.first.getAttribute("class"), equals(myClass), reason: "class should change");
       expect(mountRoot.children.first.getAttribute("height"), equals(height.toString()), reason: "haight should be added");
 
-      component.redraw();
+    controller.add(true);
+      when(component.render())
+        .thenReturn([span()]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.first.attributes, isEmpty);
@@ -338,28 +332,33 @@ main() {
 
     test("should remove all children of removed not dom component", () {
       ComponentMock componentWithSpan = new ComponentMock();
-      componentWithSpan.when(callsTo("render")).alwaysReturn([span()]);
+      when(componentWithSpan.render()).thenReturn([span()]);
 
-      componentWithSpan.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      when(componentWithSpan.shouldUpdate(any, any)).thenReturn(true);
 
       ComponentDescriptionMock descriptionWithSpan = new ComponentDescriptionMock();
-      descriptionWithSpan.when(callsTo("createComponent")).alwaysReturn(componentWithSpan);
+      when(descriptionWithSpan.createComponent()).thenReturn(componentWithSpan);
 
-      component.when(callsTo("render"))
-        .thenReturn([descriptionWithSpan])
-        .thenReturn([]);
+      when(component.render())
+        .thenReturn([descriptionWithSpan]);
 
       mountComponent(description, mountRoot);
 
       expect(mountRoot.children.length, equals(1));
       expect(mountRoot.children.first.children.length, equals(0));
 
-      component.redraw();
+    controller.add(true);
+      when(component.render())
+        .thenReturn([]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.length, equals(0));
       }));
     });
+
+    ComponentMock cmp1;
+    ComponentMock cmp2;
+    ComponentMock cmp3;
 
     ComponentDescriptionMock prepareTestCase() {
       /*
@@ -371,41 +370,54 @@ main() {
        *
        * However, we need to ensure, that div3 is inserted after div2. What if Cmp2 is updated, Cmp3 is not and div2 ends after div4?
        */
-      ComponentMock cmp1 = new ComponentMock();
-      cmp1.when(callsTo("get needUpdate"))
-        .alwaysReturn(controller.stream);
-      cmp1.when(callsTo("redraw"))
-        .alwaysCall(([bool what]) => controller.add(what));
-      cmp1.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      cmp1 = new ComponentMock();
+      when(cmp1.needUpdate)
+        .thenReturn(controller.stream);
+      when(cmp1.shouldUpdate(any, any)).thenReturn(true);
 
 
       ComponentDescriptionMock desc1 = new ComponentDescriptionMock();
-      desc1.when(callsTo("createComponent")).alwaysReturn(cmp1);
+      when(desc1.createComponent()).thenReturn(cmp1);
 
 
-      ComponentMock cmp2 = new ComponentMock();
-      cmp2.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      cmp2 = new ComponentMock();
+      when(cmp2.shouldUpdate).thenReturn(true);
       ComponentDescriptionMock desc2 = new ComponentDescriptionMock();
-      desc2.when(callsTo("createComponent")).alwaysReturn(cmp2);
+      when(desc2.createComponent()).thenReturn(cmp2);
 
-      ComponentMock cmp3 = new ComponentMock();
-      cmp3.when(callsTo("shouldUpdate")).alwaysReturn(true);
+      cmp3 = new ComponentMock();
+      when(cmp3.shouldUpdate).thenReturn(true);
       ComponentDescriptionMock desc3 = new ComponentDescriptionMock();
-      desc3.when(callsTo("createComponent")).alwaysReturn(cmp3);
+      when(desc3.createComponent()).thenReturn(cmp3);
 
-      cmp1.when(callsTo("render")).alwaysReturn([desc2, desc3]);
-      cmp2.when(callsTo("render"))
-        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})])  /*div1, div2*/
-        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})])
-        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})])
-        .thenReturn([div(props: {"id": "div1"}), span()]); // replace div2 by span
-      cmp3.when(callsTo("render"))
-        .thenReturn([div(props: {"id": "div3"}), div(props: {"id": "div4"})])
-        .thenReturn([div(props: {"id": "div3.1"}), div(props: {"id": "div4"})])
-        .thenReturn([span(), div()])
-        .thenReturn([span(), div()]);
+      when(cmp1.render()).thenReturn([desc2, desc3]);
+      when(cmp2.render())
+        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})]);  /*div1, div2*/
+      when(cmp3.render())
+        .thenReturn([div(props: {"id": "div3"}), div(props: {"id": "div4"})]);
 
       return desc1;
+    }
+    
+    turn2() {
+      when(cmp2.render())
+        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})]);
+      when(cmp3.render())
+        .thenReturn([div(props: {"id": "div3.1"}), div(props: {"id": "div4"})]);
+    }
+
+    turn3() {
+      when(cmp2.render())
+        .thenReturn([div(props: {"id": "div1"}), div(props: {"id": "div2"})]);
+      when(cmp3.render())
+        .thenReturn([span(), div()]);
+    }
+
+    turn4() {
+      when(cmp2.render())
+        .thenReturn([div(props: {"id": "div1"}), span()]); // replace div2 by span
+      when(cmp3.render())
+        .thenReturn([span(), div()]);
     }
 
     test("should only update div attributes when all children are stil div", () {
@@ -423,7 +435,8 @@ main() {
       /**
        * update just id of div3 after first update
        */
-      description.createComponent().redraw();
+      controller.add(true);
+      turn2();
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.children.length, equals(4));
@@ -452,11 +465,13 @@ main() {
       /**
        * update twice to replace div3 by span
        */
-      description.createComponent().redraw();
+      controller.add(true);
+      turn2();
 
       window.animationFrame.then(expectAsync((data) {
-        description.createComponent().redraw();
-
+        controller.add(true);
+        turn3();
+        
         window.animationFrame.then(expectAsync((data) {
           expect(mountRoot.children.length, equals(4));
 
@@ -486,12 +501,15 @@ main() {
       /**
        * update twice to replace div3 by span
        */
-      description.createComponent().redraw();
+      controller.add(true);
+      turn2();
       window.animationFrame.then(expectAsync((data) {
-        description.createComponent().redraw();
+        controller.add(true);
+        turn3();
 
         window.animationFrame.then(expectAsync((data) {
-          description.createComponent().redraw();
+          controller.add(true);
+          turn4();
 
           window.animationFrame.then(expectAsync((data) {
             expect(mountRoot.children.length, equals(4));
@@ -510,11 +528,10 @@ main() {
     test("should remove relations between component(node) and element", () {
       Component spanComponent = span().createComponent();
       ComponentDescriptionMock spanDescription = new ComponentDescriptionMock();
-      spanDescription.when(callsTo("createComponent")).alwaysReturn(spanComponent);
+      when(spanDescription.createComponent()).thenReturn(spanComponent);
 
-      component.when(callsTo("render"))
-        .thenReturn([spanDescription])
-        .thenReturn([]);
+      when(component.render())
+        .thenReturn([spanDescription]);
 
       mountComponent(description, mountRoot);
 
@@ -523,7 +540,9 @@ main() {
 
       Element spanElement = mountRoot.firstChild;
 
-      component.redraw();
+      controller.add(true);
+      when(component.render())
+        .thenReturn([]);
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.firstChild, isNull, reason: "mountRoot should be empty");
@@ -535,9 +554,8 @@ main() {
     test("should change text inside of html when update of text component ", () {
       String text1 = "hello",
           text2 = "aloha";
-      component.when(callsTo("render"))
-        .thenReturn(div(children: text1))
-        .thenReturn(div(children: text2));
+      when(component.render())
+        .thenReturn(div(children: text1));
 
       mountComponent(description, mountRoot);
 
@@ -545,7 +563,9 @@ main() {
       expect(text is Text, isTrue);
       expect(text.text, equals(text1));
 
-      component.redraw();
+      controller.add(true);
+      when(component.render())
+          .thenReturn(div(children: text2));
 
       window.animationFrame.then(expectAsync((data) {
         expect(mountRoot.firstChild.firstChild, equals(text));
@@ -557,9 +577,8 @@ main() {
       test("should update dangerously seted inner HTML", () {
         String text1 = "hello",
             text2 = "aloha";
-        component.when(callsTo("render"))
-          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}))
-          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
+        when(component.render())
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}));
 
         mountComponent(description, mountRoot);
 
@@ -567,7 +586,9 @@ main() {
         expect(text is Text, isTrue);
         expect(text.text, equals(text1));
 
-        component.redraw();
+        controller.add(true);
+        when(component.render())
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
 
         window.animationFrame.then(expectAsync((data) {
           text = mountRoot.firstChild.firstChild;
@@ -580,9 +601,8 @@ main() {
       test("should update dangerously seted more complex inner HTML", () {
         String text1 = "<span>hello</span><div>helloo</div>",
             text2 = "<div>aloha</div><span>alooha</span>";
-        component.when(callsTo("render"))
-          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}))
-          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
+        when(component.render())
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text1}));
 
         mountComponent(description, mountRoot);
 
@@ -593,7 +613,9 @@ main() {
         expect(divel.text, equals("helloo"));
         expect(spanel.text, equals("hello"));
 
-        component.redraw();
+        controller.add(true);
+        when(component.render())
+          .thenReturn(div(props: {"dangerouslySetInnerHTML": text2}));
 
         window.animationFrame.then(expectAsync((data) {
           divel = mountRoot.firstChild.firstChild;
@@ -609,16 +631,17 @@ main() {
 
       test("should create component dangerously seted inner HTML", () {
         String text = "aloha";
-        component.when(callsTo("render"))
-          .thenReturn(div())
-          .thenReturn(div(children: div(props: {"dangerouslySetInnerHTML": text})));
+        when(component.render())
+          .thenReturn(div());
 
         mountComponent(description, mountRoot);
 
         Text innerElement = mountRoot.firstChild.firstChild;
         expect(innerElement, isNull);
 
-        component.redraw();
+        controller.add(true);
+        when(component.render())
+          .thenReturn(div(children: div(props: {"dangerouslySetInnerHTML": text})));
 
         window.animationFrame.then(expectAsync((data) {
           innerElement = mountRoot.firstChild.firstChild.firstChild;

--- a/test/core/component_description_test.dart
+++ b/test/core/component_description_test.dart
@@ -1,9 +1,9 @@
 library tiles_compoenent_description_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
-import 'package:mock/mock.dart';
+import 'package:mockito/mockito.dart';
 
 main() {
   group("(ComponentDescription)", () {

--- a/test/core/component_test.dart
+++ b/test/core/component_test.dart
@@ -1,6 +1,6 @@
 library tiles_component_test;
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
 import 'dart:async';

--- a/test/core/node_change_test.dart
+++ b/test/core/node_change_test.dart
@@ -1,10 +1,10 @@
 library tiles_node_change_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
 import 'dart:math';
-import 'package:mock/mock.dart';
+import 'package:mockito/mockito.dart';
 
 main() {
 

--- a/test/core/node_test.dart
+++ b/test/core/node_test.dart
@@ -1,7 +1,7 @@
 library tiles_node_test;
 
-import 'package:unittest/unittest.dart';
-import 'package:mock/mock.dart';
+import 'package:test/test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
 import 'dart:async';
@@ -9,10 +9,6 @@ import 'dart:async';
 
 main() {
 
-//  var component = new ComponentMock()
-//    ..when(callsTo('render')).alwaysReturn([]);
-//
-//  component.getLogs(callsTo('componentWillReceiveProps')).verify(happenedOnce);
   group("(Node)", () {
     ComponentFactory factory = ({props, children}) => new Component(props);
 
@@ -53,7 +49,7 @@ main() {
     test("should listen to components need update stream and set self as dirty if component need update", () {
       StreamController<bool> controller = new StreamController();
       ComponentMock component = new ComponentMock();
-      component.when(callsTo("get needUpdate")).alwaysReturn(controller.stream);
+      when(component.needUpdate).thenReturn(controller.stream);
 
       Node node = new Node(null, component, factory);
       node.update();
@@ -68,7 +64,7 @@ main() {
 
     test("should accept ComponentDescription not in list from component.render()", () {
       ComponentMock component = new ComponentMock();
-      component.when(callsTo("render")).alwaysReturn(new ComponentDescription(({dynamic props, children}) => new ComponentMock()));
+      when(component.render()).thenReturn(new ComponentDescription(({dynamic props, children}) => new ComponentMock()));
 
       Node node = new Node(null, component, factory);
       node.update();

--- a/test/core/node_update_children_test.dart
+++ b/test/core/node_update_children_test.dart
@@ -128,7 +128,7 @@ main() {
       });
 
     });
-    
+
     test("should accept iterable as result of render", () {
       Iterable iterable = [description].reversed;
       component = new ComponentMock();
@@ -136,7 +136,7 @@ main() {
       component.when(callsTo("shouldUpdate")).alwaysReturn(true);
 
       createNode();
-      
+
       node.isDirty = true;
       node.update();
     });

--- a/test/core/node_update_children_test.dart
+++ b/test/core/node_update_children_test.dart
@@ -128,6 +128,18 @@ main() {
       });
 
     });
+    
+    test("should accept iterable as result of render", () {
+      Iterable iterable = [description].reversed;
+      component = new ComponentMock();
+      component.when(callsTo("render")).alwaysReturn(iterable);
+      component.when(callsTo("shouldUpdate")).alwaysReturn(true);
+
+      createNode();
+      
+      node.isDirty = true;
+      node.update();
+    });
 
     group("(_updateChildren)", () {
       test("update - if factory is the same, child will be the same", () {

--- a/test/core/register_component_test.dart
+++ b/test/core/register_component_test.dart
@@ -1,9 +1,9 @@
 library tiles_register_component_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
-import 'package:mock/mock.dart';
+import 'package:mockito/mockito.dart';
 
 
 main() {

--- a/test/dom/dom_component_test.dart
+++ b/test/dom/dom_component_test.dart
@@ -1,6 +1,6 @@
 library tiles_dom_component_test;
 
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:tiles/tiles.dart';
 import '../mocks.dart';
 

--- a/test/dom/dom_elements_special_test.dart
+++ b/test/dom/dom_elements_special_test.dart
@@ -1,7 +1,7 @@
 library tiles_dom_elements_special_test;
 
 import 'package:tiles/tiles.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 //import 'package:mock/mock.dart';
 import '../mocks.dart';
 //import 'package:tiles/tiles.dart';

--- a/test/dom/dom_elements_test.dart
+++ b/test/dom/dom_elements_test.dart
@@ -76,6 +76,10 @@ main() {
 
       expect(description.listeners, isNotNull);
     });
+    
+    test("should accept iterable in children", () {
+      div(children: [1,2,3].map((number) => span(children: "$number")));
+    });
 
   });
 

--- a/test/dom/dom_elements_test.dart
+++ b/test/dom/dom_elements_test.dart
@@ -1,7 +1,7 @@
 library tiles_dom_elements_test;
 
 import 'package:tiles/tiles.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 //import 'package:mock/mock.dart';
 import '../mocks.dart';
 //import 'package:tiles/tiles.dart';

--- a/test/dom/dom_text_component_test.dart
+++ b/test/dom/dom_text_component_test.dart
@@ -1,7 +1,7 @@
 library tiles_dom_text_component_test;
 
 import 'package:tiles/tiles.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 
 
 main() {

--- a/test/mocks.dart
+++ b/test/mocks.dart
@@ -1,6 +1,6 @@
 library tiles_test_mocks;
 
-import 'package:mock/mock.dart';
+import 'package:mockito/mockito.dart';
 import 'package:tiles/tiles.dart';
 import 'dart:async';
 

--- a/test/run.sh
+++ b/test/run.sh
@@ -175,7 +175,7 @@ then
 
 	test_core;
 	test_browser;
-	test_selenium;
+	# test_selenium;
 else
 	opts=`getopt cbs "$@" 2> /dev/null`
 	if [ $? -ne 0 ] 

--- a/test/selenium/bug_example/value/application_test.dart
+++ b/test/selenium/bug_example/value/application_test.dart
@@ -1,7 +1,7 @@
 library selenium_application_test;
 
 import 'package:webdriver/webdriver.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import '../../test_utils.dart';
 
 void main() {

--- a/test/selenium/simple_app/application_test.dart
+++ b/test/selenium/simple_app/application_test.dart
@@ -1,7 +1,7 @@
 library selenium_application_test;
 
 import 'package:webdriver/webdriver.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {

--- a/test/selenium/test_utils.dart
+++ b/test/selenium/test_utils.dart
@@ -3,7 +3,7 @@ library webdriver_test_util;
 import 'dart:io';
 import 'dart:async';
 import 'package:path/path.dart' as path;
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import 'package:webdriver/webdriver.dart';
 
 WebDriver driver;

--- a/test/selenium/toggle/toggle_test.dart
+++ b/test/selenium/toggle/toggle_test.dart
@@ -1,7 +1,7 @@
 library selenium_application_test;
 
 import 'package:webdriver/webdriver.dart';
-import 'package:unittest/unittest.dart';
+import 'package:test/test.dart';
 import '../test_utils.dart';
 
 void main() {


### PR DESCRIPTION
Including:

* custom events, 
* rendering continues on exception
* used iterable instead of list for children
* remount component instead of redraw full content on second mount . 
* added allowed prefixes for attributes (`data-` and `aria-`)

Fixes #41 #40 #42 #36 #39 
