### PR TITLE
Fix event listener if event cannot bubble to parent

### DIFF
--- a/lib/src/browser/events.dart
+++ b/lib/src/browser/events.dart
@@ -9,6 +9,13 @@ part of tiles_browser;
 final Map<html.Node, Node> _elementToNode = {};
 
 /**
+ * A small List used to determine if an event will bubble up to it's
+ * parent. If not, we need to listen to the event on the element itself,
+ * not use the optimizations of batching listening on the root element.
+ */
+final List<String> _nonBubblingEvents = ["scroll", "focus", "blur"];
+
+/**
  * needed to enable user of API to get element,
  * which is component mapped to.
  */
@@ -36,6 +43,12 @@ _processEvent(String key, dynamic value, Node node) {
   logger.fine("_processEvent called on key $key");
   if (!(value is EventListener)) {
     throw "there can be only EventListener in $key attribute";
+  }
+
+  // if the event cannot bubble, skip finding root node
+  if(_nonBubblingEvents.contains(key)) {
+    _registerListener(_nodeToElement[node], key);
+    return;
   }
 
   /**

--- a/lib/src/browser/events.dart
+++ b/lib/src/browser/events.dart
@@ -13,7 +13,7 @@ final Map<html.Node, Node> _elementToNode = {};
  * parent. If not, we need to listen to the event on the element itself,
  * not use the optimizations of batching listening on the root element.
  */
-final List<String> _nonBubblingEvents = ["scroll", "focus", "blur"];
+final List<String> _nonBubblingEvents = ["scroll", "focus", "blur", "load", "unload"];
 
 /**
  * needed to enable user of API to get element,


### PR DESCRIPTION
This resulted from a bug I found where I could not register a scroll event with tiles, because it listens to the event on the root node. Scroll, with some other events, will not bubble to their parents. If you find the list of non-bubbling events to be lacking, feel free to tell me some more events that need to be handled in this special fashion.

Thanks!